### PR TITLE
Add GitHub Actions workflow for NuGet publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,19 +34,18 @@ jobs:
         shell: bash
         run: |
           if [ -n "${{ github.event.inputs.version }}" ]; then
-            echo "PKGVER=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+            PKGVER="${{ github.event.inputs.version }}"
           else
             FILE=$(git ls-files '*.csproj' | head -n1)
-            VER=$(grep -oPm1 '(?<=<Version>)[^<]+' "$FILE")
-            if [ -z "$VER" ]; then
-              echo "Version not found in $FILE"; exit 1
-            fi
-            echo "PKGVER=$VER" >> $GITHUB_ENV
+            PKGVER=$(grep -oPm1 '(?<=<Version>)[^<]+' "$FILE" || true)
+            if [ -z "$PKGVER" ]; then echo "Version not found in $FILE"; exit 1; fi
           fi
-          echo "Using version: ${PKGVER}"
+          echo "PKGVER=$PKGVER" >> $GITHUB_ENV
+          echo "Using version: $PKGVER"
+
 
       - name: Pack
-        run: dotnet pack -c Release -p:Version=${PKGVER} -o ./artifacts
+        run: dotnet pack -c Release -p:Version=${PKGVER} -o ./artifacts -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
 
       - name: Push to nuget.org
         env:
@@ -56,4 +55,8 @@ jobs:
             echo "NUGET_API_KEY secret is not set."; exit 1
           fi
           dotnet nuget push "./artifacts/*.nupkg"  --skip-duplicate --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json
-          dotnet nuget push "./artifacts/*.snupkg" --skip-duplicate --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json
+          if ls ./artifacts/*.snupkg 1> /dev/null 2>&1; then
+            dotnet nuget push "./artifacts/*.snupkg" --skip-duplicate --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json
+          else
+            echo "No symbol packages (.snupkg) found to push."
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+name: publish-nuget
+
+on:
+  push:
+    branches: [ main ]     
+  workflow_dispatch: 
+    inputs:
+      version:
+        description: 'Override version (optional, e.g. 0.1.2)'
+        required: false
+        type: string
+
+jobs:
+  pack-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build -c Release
+
+      - name: Test
+        run: dotnet test -c Release --logger trx
+
+      - name: Resolve version
+        id: ver
+        shell: bash
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "PKGVER=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+          else
+            FILE=$(git ls-files '*.csproj' | head -n1)
+            VER=$(grep -oPm1 '(?<=<Version>)[^<]+' "$FILE")
+            if [ -z "$VER" ]; then
+              echo "Version not found in $FILE"; exit 1
+            fi
+            echo "PKGVER=$VER" >> $GITHUB_ENV
+          fi
+          echo "Using version: ${PKGVER}"
+
+      - name: Pack
+        run: dotnet pack -c Release -p:Version=${PKGVER} -o ./artifacts
+
+      - name: Push to nuget.org
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          if [ -z "$NUGET_API_KEY" ]; then
+            echo "NUGET_API_KEY secret is not set."; exit 1
+          fi
+          dotnet nuget push "./artifacts/*.nupkg"  --skip-duplicate --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json
+          dotnet nuget push "./artifacts/*.snupkg" --skip-duplicate --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '9.0.x'
 
       - name: Restore
         run: dotnet restore


### PR DESCRIPTION
Introduces a workflow to build, test, pack, and publish NuGet packages on pushes to main or via manual dispatch. Supports version override and handles API key securely for publishing to nuget.org.