### PR TITLE
Add typed-routed handlers and RawQueueMessage

### DIFF
--- a/DotQueue.IntegrationTests/IntegrationTests/AzureTest.cs
+++ b/DotQueue.IntegrationTests/IntegrationTests/AzureTest.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus;
 using DotQueue;
 using DotQueue.Azure;
 using Microsoft.Extensions.DependencyInjection;
@@ -61,6 +61,57 @@ public class DotQueue_Smoke
         await host.StopAsync(TimeSpan.FromSeconds(5));
     }
 
+    [Fact(Timeout = 60000)]
+    public async Task Typed_message_is_routed_by_messageType_metadata()
+    {
+        const string queueName = "demo-messages";
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var gotIt = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(s =>
+            {
+                s.AddLogging(b => b.AddSimpleConsole(o => { o.TimestampFormat = "HH:mm:ss "; o.SingleLine = true; }));
+
+                s.AddSingleton(_ => new ServiceBusClient(Conn, new ServiceBusClientOptions
+                {
+                    TransportType = ServiceBusTransportType.AmqpTcp
+                }));
+
+                s.AddSingleton(gotIt);
+
+                s.AddTypedRoutedQueue<TypedHandler>(queueName, o =>
+                {
+                    o.MaxConcurrentCalls = 1;
+                    o.PrefetchCount = 0;
+                    o.MaxRetryAttempts = 0;
+                });
+            })
+            .Build();
+
+        await host.StartAsync(cts.Token);
+        await Task.Delay(200, cts.Token);
+
+        var client = host.Services.GetRequiredService<ServiceBusClient>();
+        var sender = client.CreateSender(queueName);
+        var body = JsonSerializer.Serialize(new TypedMsg("typed-hello"));
+
+        var message = new ServiceBusMessage(body)
+        {
+            ContentType = "application/json",
+        };
+        message.ApplicationProperties[TypedRoutedQueueHandler.MessageTypeMetadataKey] = nameof(TypedMsg);
+
+        await sender.SendMessageAsync(message, cts.Token);
+
+        var receivedText = await gotIt.Task.WaitAsync(cts.Token);
+        Assert.Equal("typed-hello", receivedText);
+
+        await sender.DisposeAsync();
+        await host.StopAsync(TimeSpan.FromSeconds(5));
+    }
+
     private sealed record SimpleMsg(string Text);
 
     private sealed class SimpleHandler : IQueueHandler<SimpleMsg>
@@ -81,4 +132,27 @@ public class DotQueue_Smoke
             _tcs.TrySetResult(message.Text);
         }
     }
+
+    private sealed record TypedMsg(string Text);
+
+    private sealed class TypedHandler(
+        TaskCompletionSource<string> tcs,
+        ILogger<TypedHandler> logger) : TypedRoutedQueueHandler(logger)
+    {
+        private readonly TaskCompletionSource<string> _tcs = tcs;
+
+        protected override RouteBuilder ConfigureRoutes(RouteBuilder routeBuilder)
+            => routeBuilder.AddHandler<TypedMsg>(HandleTypedAsync);
+
+        private ValueTask HandleTypedAsync(
+            TypedMsg message,
+            IReadOnlyDictionary<string, string>? metadata,
+            Func<Task> renewLock,
+            CancellationToken ct)
+        {
+            _tcs.TrySetResult(message.Text);
+            return ValueTask.CompletedTask;
+        }
+    }
+
 }

--- a/DotQueue.IntegrationTests/IntegrationTests/AzureTest.cs
+++ b/DotQueue.IntegrationTests/IntegrationTests/AzureTest.cs
@@ -11,6 +11,7 @@ public class DotQueue_Smoke
 {
     private const string Conn =
         "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";
+    private const string TypedMessageContract = "integration-tests.typed-msg.v1";
 
     [Fact(Timeout = 60000)]
     public async Task Message_is_received()
@@ -101,7 +102,7 @@ public class DotQueue_Smoke
         {
             ContentType = "application/json",
         };
-        message.ApplicationProperties[TypedRoutedQueueHandler.MessageTypeMetadataKey] = nameof(TypedMsg);
+        message.ApplicationProperties[TypedRoutedQueueHandler.MessageTypeMetadataKey] = TypedMessageContract;
 
         await sender.SendMessageAsync(message, cts.Token);
 
@@ -135,14 +136,18 @@ public class DotQueue_Smoke
 
     private sealed record TypedMsg(string Text);
 
-    private sealed class TypedHandler(
-        TaskCompletionSource<string> tcs,
-        ILogger<TypedHandler> logger) : TypedRoutedQueueHandler(logger)
+    private sealed class TypedHandler : TypedRoutedQueueHandler
     {
-        private readonly TaskCompletionSource<string> _tcs = tcs;
+        private readonly TaskCompletionSource<string> _tcs;
+
+        public TypedHandler(TaskCompletionSource<string> tcs, ILogger<TypedHandler> logger) : base(logger)
+        {
+            _tcs = tcs;
+            InitializeRoutes();
+        }
 
         protected override RouteBuilder ConfigureRoutes(RouteBuilder routeBuilder)
-            => routeBuilder.AddHandler<TypedMsg>(HandleTypedAsync);
+            => routeBuilder.AddHandler<TypedMsg>(TypedMessageContract, HandleTypedAsync);
 
         private ValueTask HandleTypedAsync(
             TypedMsg message,

--- a/DotQueue.IntegrationTests/IntegrationTests/RabbitTest.cs
+++ b/DotQueue.IntegrationTests/IntegrationTests/RabbitTest.cs
@@ -18,6 +18,7 @@ public class DotQueue_Rabbit_Smoke
 {
     private const string Amqp =
         "amqp://admin:admin@localhost:5673/";
+    private const string TypedMessageContract = "integration-tests.rabbit-typed-msg.v1";
 
     [Fact(Timeout = 60000)]
     public async Task Message_is_received()
@@ -140,7 +141,7 @@ public class DotQueue_Rabbit_Smoke
                 ContentType = "application/json",
                 Headers = new Dictionary<string, object?>
                 {
-                    [TypedRoutedQueueHandler.MessageTypeMetadataKey] = Encoding.UTF8.GetBytes(nameof(TypedMsg)),
+                    [TypedRoutedQueueHandler.MessageTypeMetadataKey] = Encoding.UTF8.GetBytes(TypedMessageContract),
                 },
             },
             body,
@@ -175,14 +176,18 @@ public class DotQueue_Rabbit_Smoke
 
     private sealed record TypedMsg(string Text);
 
-    private sealed class TypedHandler(
-        TaskCompletionSource<string> tcs,
-        ILogger<TypedHandler> logger) : TypedRoutedQueueHandler(logger)
+    private sealed class TypedHandler : TypedRoutedQueueHandler
     {
-        private readonly TaskCompletionSource<string> _tcs = tcs;
+        private readonly TaskCompletionSource<string> _tcs;
+
+        public TypedHandler(TaskCompletionSource<string> tcs, ILogger<TypedHandler> logger) : base(logger)
+        {
+            _tcs = tcs;
+            InitializeRoutes();
+        }
 
         protected override RouteBuilder ConfigureRoutes(RouteBuilder routeBuilder)
-            => routeBuilder.AddHandler<TypedMsg>(HandleTypedAsync);
+            => routeBuilder.AddHandler<TypedMsg>(TypedMessageContract, HandleTypedAsync);
 
         private ValueTask HandleTypedAsync(
             TypedMsg message,

--- a/DotQueue.IntegrationTests/IntegrationTests/RabbitTest.cs
+++ b/DotQueue.IntegrationTests/IntegrationTests/RabbitTest.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -78,6 +79,79 @@ public class DotQueue_Rabbit_Smoke
         await host.StopAsync(TimeSpan.FromSeconds(5));
     }
 
+    [Fact(Timeout = 60000)]
+    public async Task Typed_message_is_routed_by_messageType_header()
+    {
+        const string queueName = "demo-typed-messages";
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        await EnsureQueueExistsAsync(queueName, cts.Token);
+
+        var gotIt = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(s =>
+            {
+                s.AddLogging(b => b.AddSimpleConsole(o =>
+                {
+                    o.TimestampFormat = "HH:mm:ss ";
+                    o.SingleLine = true;
+                }));
+
+                s.AddSingleton(gotIt);
+
+                s.AddTypedRoutedRabbitMQQueue<TypedHandler>(
+                    amqpConnectionString: Amqp,
+                    queueName: queueName,
+                    configure: o =>
+                    {
+                        o.MaxConcurrentCalls = 1;
+                        o.PrefetchCount = 0;
+                        o.MaxRetryAttempts = 0;
+                    });
+            })
+            .Build();
+
+        await host.StartAsync(cts.Token);
+
+        var factory = new ConnectionFactory { Uri = new Uri(Amqp) };
+        await using var conn = await factory.CreateConnectionAsync(cts.Token);
+        await using var ch = await conn.CreateChannelAsync(cancellationToken: cts.Token);
+
+        for (var i = 0; i < 100; i++)
+        {
+            await using var probe = await conn.CreateChannelAsync(cancellationToken: cts.Token);
+            try
+            {
+                var q = await probe.QueueDeclarePassiveAsync(queueName, cts.Token);
+                if (q.ConsumerCount > 0) break;
+            }
+            catch { }
+            await Task.Delay(100, cts.Token);
+        }
+
+        var body = JsonSerializer.SerializeToUtf8Bytes(new TypedMsg("typed-hello"));
+        await ch.BasicPublishAsync(
+            "",
+            queueName,
+            false,
+            new BasicProperties
+            {
+                ContentType = "application/json",
+                Headers = new Dictionary<string, object?>
+                {
+                    [TypedRoutedQueueHandler.MessageTypeMetadataKey] = Encoding.UTF8.GetBytes(nameof(TypedMsg)),
+                },
+            },
+            body,
+            cts.Token);
+
+        var receivedText = await gotIt.Task.WaitAsync(cts.Token);
+        Assert.Equal("typed-hello", receivedText);
+
+        await host.StopAsync(TimeSpan.FromSeconds(5));
+    }
+
     private sealed record SimpleMsg(string Text);
 
     private sealed class SimpleHandler : IQueueHandler<SimpleMsg>
@@ -97,5 +171,42 @@ public class DotQueue_Rabbit_Smoke
             await complete();
             _tcs.TrySetResult(message.Text);
         }
+    }
+
+    private sealed record TypedMsg(string Text);
+
+    private sealed class TypedHandler(
+        TaskCompletionSource<string> tcs,
+        ILogger<TypedHandler> logger) : TypedRoutedQueueHandler(logger)
+    {
+        private readonly TaskCompletionSource<string> _tcs = tcs;
+
+        protected override RouteBuilder ConfigureRoutes(RouteBuilder routeBuilder)
+            => routeBuilder.AddHandler<TypedMsg>(HandleTypedAsync);
+
+        private ValueTask HandleTypedAsync(
+            TypedMsg message,
+            IReadOnlyDictionary<string, string>? metadata,
+            Func<Task> renewLock,
+            CancellationToken ct)
+        {
+            _tcs.TrySetResult(message.Text);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static async Task EnsureQueueExistsAsync(string queueName, CancellationToken ct)
+    {
+        var factory = new ConnectionFactory { Uri = new Uri(Amqp) };
+        await using var conn = await factory.CreateConnectionAsync(ct);
+        await using var ch = await conn.CreateChannelAsync(cancellationToken: ct);
+
+        await ch.QueueDeclareAsync(
+            queue: queueName,
+            durable: true,
+            exclusive: false,
+            autoDelete: false,
+            arguments: null,
+            cancellationToken: ct);
     }
 }

--- a/DotQueue.Tests/RabbitMqServiceCollectionExtensionsTests.cs
+++ b/DotQueue.Tests/RabbitMqServiceCollectionExtensionsTests.cs
@@ -17,11 +17,12 @@ public class RabbitMqServiceCollectionExtensionsTests
             CancellationToken cancellationToken) => Task.CompletedTask;
     }
 
-    private sealed class DummyTypedHandler(ILogger<DummyTypedHandler> logger)
-        : TypedRoutedQueueHandler(logger)
+    private sealed class DummyTypedHandler : TypedRoutedQueueHandler
     {
+        public DummyTypedHandler(ILogger<DummyTypedHandler> logger) : base(logger) => InitializeRoutes();
+
         protected override RouteBuilder ConfigureRoutes(RouteBuilder routeBuilder)
-            => routeBuilder.AddHandler<DummyMessage>(HandleAsync);
+            => routeBuilder.AddHandler<DummyMessage>("tests.rabbit-dummy.v1", HandleAsync);
 
         private static ValueTask HandleAsync(
             DummyMessage message,

--- a/DotQueue.Tests/RabbitMqServiceCollectionExtensionsTests.cs
+++ b/DotQueue.Tests/RabbitMqServiceCollectionExtensionsTests.cs
@@ -1,0 +1,69 @@
+using DotQueue.Rabbit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace DotQueue.Tests;
+
+public class RabbitMqServiceCollectionExtensionsTests
+{
+    private sealed class DummyHandler : IQueueHandler<string>
+    {
+        public Task HandleAsync(
+            string message,
+            IReadOnlyDictionary<string, string>? metadata,
+            Func<Task> renewLock,
+            CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    private sealed class DummyTypedHandler(ILogger<DummyTypedHandler> logger)
+        : TypedRoutedQueueHandler(logger)
+    {
+        protected override RouteBuilder ConfigureRoutes(RouteBuilder routeBuilder)
+            => routeBuilder.AddHandler<DummyMessage>(HandleAsync);
+
+        private static ValueTask HandleAsync(
+            DummyMessage message,
+            IReadOnlyDictionary<string, string>? metadata,
+            Func<Task> renewLock,
+            CancellationToken ct) => ValueTask.CompletedTask;
+    }
+
+    private sealed record DummyMessage(string Text);
+
+    [Fact]
+    public void AddRabbitQueue_Registers_Default_Pipeline()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddRabbitMQQueue<string, DummyHandler>(
+            amqpConnectionString: "amqp://guest:guest@localhost:5672/",
+            queueName: "queue-name");
+
+        var sp = services.BuildServiceProvider();
+
+        sp.GetService<IQueueListener<string>>().Should().NotBeNull();
+        sp.GetServices<Microsoft.Extensions.Hosting.IHostedService>().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void AddTypedRoutedRabbitQueue_Registers_Raw_Pipeline()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddTypedRoutedRabbitMQQueue<DummyTypedHandler>(
+            amqpConnectionString: "amqp://guest:guest@localhost:5672/",
+            queueName: "typed-queue-name");
+
+        var sp = services.BuildServiceProvider();
+
+        sp.GetService<IQueueListener<RawQueueMessage>>().Should().NotBeNull();
+        sp.GetServices<Microsoft.Extensions.Hosting.IHostedService>().Should().NotBeEmpty();
+
+        using var scope = sp.CreateScope();
+        scope.ServiceProvider.GetRequiredService<IQueueHandler<RawQueueMessage>>().Should().BeOfType<DummyTypedHandler>();
+    }
+}

--- a/DotQueue.Tests/ServiceCollectionExtensionsTests.cs
+++ b/DotQueue.Tests/ServiceCollectionExtensionsTests.cs
@@ -14,11 +14,12 @@ public class ServiceCollectionExtensionsTests
         public Task HandleAsync(string message, IReadOnlyDictionary<string, string>? metadata, Func<Task> renewLock, CancellationToken cancellationToken) => Task.CompletedTask;
     }
 
-    private sealed class DummyTypedRoutedHandler(ILogger<DummyTypedRoutedHandler> logger)
-        : TypedRoutedQueueHandler(logger)
+    private sealed class DummyTypedRoutedHandler : TypedRoutedQueueHandler
     {
+        public DummyTypedRoutedHandler(ILogger<DummyTypedRoutedHandler> logger) : base(logger) => InitializeRoutes();
+
         protected override RouteBuilder ConfigureRoutes(RouteBuilder routeBuilder)
-            => routeBuilder.AddHandler<DummyTypedMessage>(HandleAsync);
+            => routeBuilder.AddHandler<DummyTypedMessage>("tests.dummy-typed.v1", HandleAsync);
 
         private static ValueTask HandleAsync(
             DummyTypedMessage message,

--- a/DotQueue.Tests/ServiceCollectionExtensionsTests.cs
+++ b/DotQueue.Tests/ServiceCollectionExtensionsTests.cs
@@ -2,6 +2,7 @@ using Azure.Messaging.ServiceBus;
 using DotQueue.Azure;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace DotQueue.Tests;
@@ -12,6 +13,21 @@ public class ServiceCollectionExtensionsTests
     {
         public Task HandleAsync(string message, IReadOnlyDictionary<string, string>? metadata, Func<Task> renewLock, CancellationToken cancellationToken) => Task.CompletedTask;
     }
+
+    private sealed class DummyTypedRoutedHandler(ILogger<DummyTypedRoutedHandler> logger)
+        : TypedRoutedQueueHandler(logger)
+    {
+        protected override RouteBuilder ConfigureRoutes(RouteBuilder routeBuilder)
+            => routeBuilder.AddHandler<DummyTypedMessage>(HandleAsync);
+
+        private static ValueTask HandleAsync(
+            DummyTypedMessage message,
+            IReadOnlyDictionary<string, string>? metadata,
+            Func<Task> renewLock,
+            CancellationToken ct) => ValueTask.CompletedTask;
+    }
+
+    private sealed record DummyTypedMessage(string Value);
 
     [Fact]
     public void AddQueueServiceCollectionTest()
@@ -40,5 +56,51 @@ public class ServiceCollectionExtensionsTests
 
         using var scope = sp.CreateScope();
         scope.ServiceProvider.GetRequiredService<IQueueHandler<string>>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddTypedRoutedQueue_Registers_Raw_Listener_And_Handler()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton(new ServiceBusClient("Endpoint=sb://localhost/;SharedAccessKeyName=Dummy;SharedAccessKey=Dummy"));
+        services.AddSingleton<IRetryPolicyProvider, RetryPolicyProvider>();
+        services.AddLogging();
+
+        services.AddTypedRoutedQueue<DummyTypedRoutedHandler>("typed-queue-name");
+
+        var sp = services.BuildServiceProvider();
+
+        var listener = sp.GetService<IQueueListener<RawQueueMessage>>();
+        listener.Should().NotBeNull();
+
+        var hosted = sp.GetServices<Microsoft.Extensions.Hosting.IHostedService>();
+        hosted.Should().NotBeEmpty();
+
+        using var scope = sp.CreateScope();
+        scope.ServiceProvider.GetRequiredService<IQueueHandler<RawQueueMessage>>().Should().BeOfType<DummyTypedRoutedHandler>();
+    }
+
+    [Fact]
+    public void AddTypedRoutedSessionQueue_Registers_Raw_Listener_And_Handler()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton(new ServiceBusClient("Endpoint=sb://localhost/;SharedAccessKeyName=Dummy;SharedAccessKey=Dummy"));
+        services.AddSingleton<IRetryPolicyProvider, RetryPolicyProvider>();
+        services.AddLogging();
+
+        services.AddTypedRoutedSessionQueue<DummyTypedRoutedHandler>("typed-session-queue");
+
+        var sp = services.BuildServiceProvider();
+
+        var listener = sp.GetService<IQueueListener<RawQueueMessage>>();
+        listener.Should().NotBeNull();
+
+        var hosted = sp.GetServices<Microsoft.Extensions.Hosting.IHostedService>();
+        hosted.Should().NotBeEmpty();
+
+        using var scope = sp.CreateScope();
+        scope.ServiceProvider.GetRequiredService<IQueueHandler<RawQueueMessage>>().Should().BeOfType<DummyTypedRoutedHandler>();
     }
 }

--- a/DotQueue.Tests/TypedRoutedQueueHandlerTests.cs
+++ b/DotQueue.Tests/TypedRoutedQueueHandlerTests.cs
@@ -1,0 +1,238 @@
+using DotQueue;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace DotQueue.Tests;
+
+public class TypedRoutedQueueHandlerTests
+{
+    private sealed record ContextMessage(string Source);
+    private sealed record DecisionInput(int Count);
+    private sealed record DecisionResult(string Value);
+
+    private sealed class TestTypedHandler : TypedRoutedQueueHandler
+    {
+        public int ContextCalls { get; private set; }
+        public int DecisionCalls { get; private set; }
+        public int RenewCalls { get; private set; }
+        public IReadOnlyDictionary<string, string>? LastMetadata { get; private set; }
+        public DecisionResult? LastResult { get; private set; }
+
+        public TestTypedHandler(ILogger logger) : base(logger) { }
+
+        protected override RouteBuilder ConfigureRoutes(RouteBuilder routeBuilder)
+            => routeBuilder
+                .AddHandler<ContextMessage>(HandleContextAsync)
+                .AddHandler<DecisionInput, DecisionResult>(HandleDecisionAsync);
+
+        private async ValueTask HandleContextAsync(
+            ContextMessage message,
+            IReadOnlyDictionary<string, string>? metadata,
+            Func<Task> renewLock,
+            CancellationToken ct)
+        {
+            LastMetadata = metadata;
+            await renewLock();
+            RenewCalls++;
+            ContextCalls++;
+        }
+
+        private ValueTask<DecisionResult> HandleDecisionAsync(
+            DecisionInput message,
+            IReadOnlyDictionary<string, string>? metadata,
+            Func<Task> renewLock,
+            CancellationToken ct)
+        {
+            LastMetadata = metadata;
+            DecisionCalls++;
+            LastResult = new DecisionResult($"decision-{message.Count}");
+            return ValueTask.FromResult(LastResult);
+        }
+    }
+
+    private sealed class WrappedInvocationTypedHandler : TypedRoutedQueueHandler
+    {
+        public bool WasWrapped { get; private set; }
+        public Type? LastType { get; private set; }
+        public int Calls { get; private set; }
+
+        public WrappedInvocationTypedHandler(ILogger logger) : base(logger) { }
+
+        protected override RouteBuilder ConfigureRoutes(RouteBuilder routeBuilder)
+            => routeBuilder.AddHandler<ContextMessage>(HandleContextAsync);
+
+        protected override async ValueTask InvokeHandlerAsync(
+            Type messageType,
+            HandlerDelegate handler,
+            object message,
+            IReadOnlyDictionary<string, string>? metadata,
+            Func<Task> renewLock,
+            CancellationToken ct)
+        {
+            WasWrapped = true;
+            LastType = messageType;
+            await handler(message, metadata, renewLock, ct);
+        }
+
+        private ValueTask HandleContextAsync(
+            ContextMessage message,
+            IReadOnlyDictionary<string, string>? metadata,
+            Func<Task> renewLock,
+            CancellationToken ct)
+        {
+            Calls++;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task Routes_By_MessageType_And_Passes_Metadata_And_RenewLock()
+    {
+        var logger = Mock.Of<ILogger>();
+        var handler = new TestTypedHandler(logger);
+
+        var metadata = new Dictionary<string, string>
+        {
+            [TypedRoutedQueueHandler.MessageTypeMetadataKey] = nameof(ContextMessage),
+            ["traceId"] = "t1",
+        };
+
+        var renewCount = 0;
+        Task Renew()
+        {
+            renewCount++;
+            return Task.CompletedTask;
+        }
+
+        await handler.HandleAsync(
+            new RawQueueMessage("""{"source":"student-feed"}"""),
+            metadata,
+            Renew,
+            CancellationToken.None);
+
+        handler.ContextCalls.Should().Be(1);
+        handler.DecisionCalls.Should().Be(0);
+        handler.RenewCalls.Should().Be(1);
+        renewCount.Should().Be(1);
+        handler.LastMetadata.Should().NotBeNull();
+        handler.LastMetadata!["traceId"].Should().Be("t1");
+    }
+
+    [Fact]
+    public async Task AddHandler_With_Response_Executes_And_Result_Is_Created()
+    {
+        var logger = Mock.Of<ILogger>();
+        var handler = new TestTypedHandler(logger);
+
+        var metadata = new Dictionary<string, string>
+        {
+            [TypedRoutedQueueHandler.MessageTypeMetadataKey] = "decisioninput",
+        };
+
+        await handler.HandleAsync(
+            new RawQueueMessage("""{"count":3}"""),
+            metadata,
+            () => Task.CompletedTask,
+            CancellationToken.None);
+
+        handler.DecisionCalls.Should().Be(1);
+        handler.LastResult.Should().NotBeNull();
+        handler.LastResult!.Value.Should().Be("decision-3");
+    }
+
+    [Fact]
+    public async Task FullName_MessageType_Is_Also_Supported()
+    {
+        var logger = Mock.Of<ILogger>();
+        var handler = new TestTypedHandler(logger);
+
+        var metadata = new Dictionary<string, string>
+        {
+            [TypedRoutedQueueHandler.MessageTypeMetadataKey] = typeof(ContextMessage).FullName!,
+        };
+
+        await handler.HandleAsync(
+            new RawQueueMessage("""{"source":"full-name"}"""),
+            metadata,
+            () => Task.CompletedTask,
+            CancellationToken.None);
+
+        handler.ContextCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Missing_MessageType_Is_NonRetryable()
+    {
+        var logger = Mock.Of<ILogger>();
+        var handler = new TestTypedHandler(logger);
+
+        var act = () => handler.HandleAsync(
+            new RawQueueMessage("""{"source":"x"}"""),
+            new Dictionary<string, string>(),
+            () => Task.CompletedTask,
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<NonRetryableException>()
+            .WithMessage("*Missing required metadata key*");
+    }
+
+    [Fact]
+    public async Task Unknown_MessageType_Is_NonRetryable()
+    {
+        var logger = Mock.Of<ILogger>();
+        var handler = new TestTypedHandler(logger);
+
+        var act = () => handler.HandleAsync(
+            new RawQueueMessage("""{"source":"x"}"""),
+            new Dictionary<string, string>
+            {
+                [TypedRoutedQueueHandler.MessageTypeMetadataKey] = "UnknownMessage",
+            },
+            () => Task.CompletedTask,
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<NonRetryableException>()
+            .WithMessage("*No handler registered for messageType*");
+    }
+
+    [Fact]
+    public async Task Invalid_Json_Is_NonRetryable()
+    {
+        var logger = Mock.Of<ILogger>();
+        var handler = new TestTypedHandler(logger);
+
+        var act = () => handler.HandleAsync(
+            new RawQueueMessage("""{"source":}"""),
+            new Dictionary<string, string>
+            {
+                [TypedRoutedQueueHandler.MessageTypeMetadataKey] = nameof(ContextMessage),
+            },
+            () => Task.CompletedTask,
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<NonRetryableException>()
+            .WithMessage("*Failed to deserialize*");
+    }
+
+    [Fact]
+    public async Task HandleAsync_Uses_InvokeHandlerAsync_For_Resolved_Types()
+    {
+        var logger = Mock.Of<ILogger>();
+        var handler = new WrappedInvocationTypedHandler(logger);
+
+        await handler.HandleAsync(
+            new RawQueueMessage("""{"source":"wrapped"}"""),
+            new Dictionary<string, string>
+            {
+                [TypedRoutedQueueHandler.MessageTypeMetadataKey] = nameof(ContextMessage),
+            },
+            () => Task.CompletedTask,
+            CancellationToken.None);
+
+        handler.WasWrapped.Should().BeTrue();
+        handler.LastType.Should().Be(typeof(ContextMessage));
+        handler.Calls.Should().Be(1);
+    }
+}

--- a/DotQueue.Tests/TypedRoutedQueueHandlerTests.cs
+++ b/DotQueue.Tests/TypedRoutedQueueHandlerTests.cs
@@ -8,9 +8,11 @@ namespace DotQueue.Tests;
 
 public class TypedRoutedQueueHandlerTests
 {
+    private const string ContextContractKey = "tests.context.v1";
+    private const string DecisionContractKey = "tests.decision-input.v1";
+
     private sealed record ContextMessage(string Source);
     private sealed record DecisionInput(int Count);
-    private sealed record DecisionResult(string Value);
 
     private sealed class TestTypedHandler : TypedRoutedQueueHandler
     {
@@ -18,14 +20,14 @@ public class TypedRoutedQueueHandlerTests
         public int DecisionCalls { get; private set; }
         public int RenewCalls { get; private set; }
         public IReadOnlyDictionary<string, string>? LastMetadata { get; private set; }
-        public DecisionResult? LastResult { get; private set; }
+        public int LastDecisionCount { get; private set; }
 
-        public TestTypedHandler(ILogger logger) : base(logger) { }
+        public TestTypedHandler(ILogger logger) : base(logger) => InitializeRoutes();
 
         protected override RouteBuilder ConfigureRoutes(RouteBuilder routeBuilder)
             => routeBuilder
-                .AddHandler<ContextMessage>(HandleContextAsync)
-                .AddHandler<DecisionInput, DecisionResult>(HandleDecisionAsync);
+                .AddHandler<ContextMessage>(ContextContractKey, HandleContextAsync)
+                .AddHandler<DecisionInput>(DecisionContractKey, HandleDecisionAsync);
 
         private async ValueTask HandleContextAsync(
             ContextMessage message,
@@ -39,7 +41,7 @@ public class TypedRoutedQueueHandlerTests
             ContextCalls++;
         }
 
-        private ValueTask<DecisionResult> HandleDecisionAsync(
+        private ValueTask HandleDecisionAsync(
             DecisionInput message,
             IReadOnlyDictionary<string, string>? metadata,
             Func<Task> renewLock,
@@ -47,8 +49,8 @@ public class TypedRoutedQueueHandlerTests
         {
             LastMetadata = metadata;
             DecisionCalls++;
-            LastResult = new DecisionResult($"decision-{message.Count}");
-            return ValueTask.FromResult(LastResult);
+            LastDecisionCount = message.Count;
+            return ValueTask.CompletedTask;
         }
     }
 
@@ -58,10 +60,10 @@ public class TypedRoutedQueueHandlerTests
         public Type? LastType { get; private set; }
         public int Calls { get; private set; }
 
-        public WrappedInvocationTypedHandler(ILogger logger) : base(logger) { }
+        public WrappedInvocationTypedHandler(ILogger logger) : base(logger) => InitializeRoutes();
 
         protected override RouteBuilder ConfigureRoutes(RouteBuilder routeBuilder)
-            => routeBuilder.AddHandler<ContextMessage>(HandleContextAsync);
+            => routeBuilder.AddHandler<ContextMessage>(ContextContractKey, HandleContextAsync);
 
         protected override async ValueTask InvokeHandlerAsync(
             Type messageType,
@@ -95,7 +97,7 @@ public class TypedRoutedQueueHandlerTests
 
         var metadata = new Dictionary<string, string>
         {
-            [TypedRoutedQueueHandler.MessageTypeMetadataKey] = nameof(ContextMessage),
+            [TypedRoutedQueueHandler.MessageTypeMetadataKey] = ContextContractKey,
             ["traceId"] = "t1",
         };
 
@@ -121,14 +123,14 @@ public class TypedRoutedQueueHandlerTests
     }
 
     [Fact]
-    public async Task AddHandler_With_Response_Executes_And_Result_Is_Created()
+    public async Task Routes_Using_Stable_Contract_Key_Not_Type_Name()
     {
         var logger = Mock.Of<ILogger>();
         var handler = new TestTypedHandler(logger);
 
         var metadata = new Dictionary<string, string>
         {
-            [TypedRoutedQueueHandler.MessageTypeMetadataKey] = "decisioninput",
+            [TypedRoutedQueueHandler.MessageTypeMetadataKey] = DecisionContractKey,
         };
 
         await handler.HandleAsync(
@@ -138,28 +140,7 @@ public class TypedRoutedQueueHandlerTests
             CancellationToken.None);
 
         handler.DecisionCalls.Should().Be(1);
-        handler.LastResult.Should().NotBeNull();
-        handler.LastResult!.Value.Should().Be("decision-3");
-    }
-
-    [Fact]
-    public async Task FullName_MessageType_Is_Also_Supported()
-    {
-        var logger = Mock.Of<ILogger>();
-        var handler = new TestTypedHandler(logger);
-
-        var metadata = new Dictionary<string, string>
-        {
-            [TypedRoutedQueueHandler.MessageTypeMetadataKey] = typeof(ContextMessage).FullName!,
-        };
-
-        await handler.HandleAsync(
-            new RawQueueMessage("""{"source":"full-name"}"""),
-            metadata,
-            () => Task.CompletedTask,
-            CancellationToken.None);
-
-        handler.ContextCalls.Should().Be(1);
+        handler.LastDecisionCount.Should().Be(3);
     }
 
     [Fact]
@@ -207,7 +188,7 @@ public class TypedRoutedQueueHandlerTests
             new RawQueueMessage("""{"source":}"""),
             new Dictionary<string, string>
             {
-                [TypedRoutedQueueHandler.MessageTypeMetadataKey] = nameof(ContextMessage),
+                [TypedRoutedQueueHandler.MessageTypeMetadataKey] = ContextContractKey,
             },
             () => Task.CompletedTask,
             CancellationToken.None);
@@ -226,7 +207,7 @@ public class TypedRoutedQueueHandlerTests
             new RawQueueMessage("""{"source":"wrapped"}"""),
             new Dictionary<string, string>
             {
-                [TypedRoutedQueueHandler.MessageTypeMetadataKey] = nameof(ContextMessage),
+                [TypedRoutedQueueHandler.MessageTypeMetadataKey] = ContextContractKey,
             },
             () => Task.CompletedTask,
             CancellationToken.None);

--- a/DotQueue/Azure/AzureServiceBusQueueListener.cs
+++ b/DotQueue/Azure/AzureServiceBusQueueListener.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
 
@@ -67,11 +67,7 @@ public class AzureServiceBusQueueListener<T> : IQueueListener<T>, IAsyncDisposab
             {
                 var json = args.Message.Body.ToString();
                 _logger.LogDebug("Raw message body: {Json}", json);
-                var jsonOptions = new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true,
-                };
-                var msg = JsonSerializer.Deserialize<T>(json, jsonOptions);
+                var msg = DeserializeMessage(json);
 
                 if (msg == null)
                 {
@@ -154,6 +150,21 @@ public class AzureServiceBusQueueListener<T> : IQueueListener<T>, IAsyncDisposab
     {
         await _processor.DisposeAsync();
         GC.SuppressFinalize(this);
+    }
+
+    private static T? DeserializeMessage(string json)
+    {
+        if (typeof(T) == typeof(RawQueueMessage))
+        {
+            return (T)(object)new RawQueueMessage(json);
+        }
+
+        var jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+        };
+
+        return JsonSerializer.Deserialize<T>(json, jsonOptions);
     }
 }
 

--- a/DotQueue/Azure/AzureServiceBusQueueListener.cs
+++ b/DotQueue/Azure/AzureServiceBusQueueListener.cs
@@ -6,6 +6,11 @@ namespace DotQueue.Azure;
 
 public class AzureServiceBusQueueListener<T> : IQueueListener<T>, IAsyncDisposable
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
     private readonly ServiceBusProcessor _processor;
     private readonly IRetryPolicyProvider _retryPolicyProvider;
     private readonly QueueSettings _settings;
@@ -159,12 +164,7 @@ public class AzureServiceBusQueueListener<T> : IQueueListener<T>, IAsyncDisposab
             return (T)(object)new RawQueueMessage(json);
         }
 
-        var jsonOptions = new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true,
-        };
-
-        return JsonSerializer.Deserialize<T>(json, jsonOptions);
+        return JsonSerializer.Deserialize<T>(json, JsonOptions);
     }
 }
 

--- a/DotQueue/Azure/AzureServiceBusSessionQueueListener.cs
+++ b/DotQueue/Azure/AzureServiceBusSessionQueueListener.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
 
@@ -66,11 +66,7 @@ public class AzureServiceBusSessionQueueListener<T> : IQueueListener<T>, IAsyncD
             {
                 var json = args.Message.Body.ToString();
                 _logger.LogDebug("Raw message body: {Json}", json);
-                var jsonOptions = new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true,
-                };
-                var msg = JsonSerializer.Deserialize<T>(json, jsonOptions);
+                var msg = DeserializeMessage(json);
                 if (msg == null)
                 {
                     _logger.LogWarning("Failed to deserialize message.");
@@ -152,5 +148,20 @@ public class AzureServiceBusSessionQueueListener<T> : IQueueListener<T>, IAsyncD
     {
         await _processor.DisposeAsync();
         GC.SuppressFinalize(this);
+    }
+
+    private static T? DeserializeMessage(string json)
+    {
+        if (typeof(T) == typeof(RawQueueMessage))
+        {
+            return (T)(object)new RawQueueMessage(json);
+        }
+
+        var jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+        };
+
+        return JsonSerializer.Deserialize<T>(json, jsonOptions);
     }
 }

--- a/DotQueue/Azure/AzureServiceBusSessionQueueListener.cs
+++ b/DotQueue/Azure/AzureServiceBusSessionQueueListener.cs
@@ -6,6 +6,11 @@ namespace DotQueue.Azure;
 
 public class AzureServiceBusSessionQueueListener<T> : IQueueListener<T>, IAsyncDisposable
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
     private readonly ServiceBusSessionProcessor _processor;
     private readonly IRetryPolicyProvider _retryPolicyProvider;
     private readonly QueueSettings _settings;
@@ -157,11 +162,6 @@ public class AzureServiceBusSessionQueueListener<T> : IQueueListener<T>, IAsyncD
             return (T)(object)new RawQueueMessage(json);
         }
 
-        var jsonOptions = new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true,
-        };
-
-        return JsonSerializer.Deserialize<T>(json, jsonOptions);
+        return JsonSerializer.Deserialize<T>(json, JsonOptions);
     }
 }

--- a/DotQueue/Azure/ServiceCollectionExtensions.cs
+++ b/DotQueue/Azure/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -54,6 +54,60 @@ public static class ServiceCollectionExtensions
                 sp.GetRequiredService<ILogger<AzureServiceBusSessionQueueListener<T>>>()));
 
         services.AddHostedService<QueueProcessor<T>>();
+
+        return services;
+    }
+
+    public static IServiceCollection AddTypedRoutedQueue<TRoutedHandler>(
+        this IServiceCollection services,
+        string queueName,
+        Action<QueueSettings>? configure = null)
+        where TRoutedHandler : TypedRoutedQueueHandler
+    {
+        services.AddScoped<TRoutedHandler>();
+        services.AddScoped<IQueueHandler<RawQueueMessage>>(sp => sp.GetRequiredService<TRoutedHandler>());
+
+        var settings = new QueueSettings();
+        configure?.Invoke(settings);
+        services.AddSingleton(settings);
+        services.AddSingleton<IRetryPolicyProvider, RetryPolicyProvider>();
+
+        services.AddSingleton<IQueueListener<RawQueueMessage>>(sp =>
+            new AzureServiceBusQueueListener<RawQueueMessage>(
+                sp.GetRequiredService<ServiceBusClient>(),
+                queueName,
+                settings,
+                sp.GetRequiredService<IRetryPolicyProvider>(),
+                sp.GetRequiredService<ILogger<AzureServiceBusQueueListener<RawQueueMessage>>>()));
+
+        services.AddHostedService<QueueProcessor<RawQueueMessage>>();
+
+        return services;
+    }
+
+    public static IServiceCollection AddTypedRoutedSessionQueue<TRoutedHandler>(
+        this IServiceCollection services,
+        string queueName,
+        Action<QueueSettings>? configure = null)
+        where TRoutedHandler : TypedRoutedQueueHandler
+    {
+        services.AddScoped<TRoutedHandler>();
+        services.AddScoped<IQueueHandler<RawQueueMessage>>(sp => sp.GetRequiredService<TRoutedHandler>());
+
+        var settings = new QueueSettings();
+        configure?.Invoke(settings);
+        services.AddSingleton(settings);
+        services.AddSingleton<IRetryPolicyProvider, RetryPolicyProvider>();
+
+        services.AddSingleton<IQueueListener<RawQueueMessage>>(sp =>
+            new AzureServiceBusSessionQueueListener<RawQueueMessage>(
+                sp.GetRequiredService<ServiceBusClient>(),
+                queueName,
+                settings,
+                sp.GetRequiredService<IRetryPolicyProvider>(),
+                sp.GetRequiredService<ILogger<AzureServiceBusSessionQueueListener<RawQueueMessage>>>()));
+
+        services.AddHostedService<QueueProcessor<RawQueueMessage>>();
 
         return services;
     }

--- a/DotQueue/DotQueue.csproj
+++ b/DotQueue/DotQueue.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>DotQueue</PackageId>
-    <Version>1.1.1</Version>
+    <Version>1.2.0</Version>
     <Authors>Alexander Kulyabin</Authors>
     <Company>Zionet</Company>
     <Description>Generic queue listener</Description>

--- a/DotQueue/README.md
+++ b/DotQueue/README.md
@@ -1,4 +1,4 @@
-do# DotQueue
+# DotQueue
 Provider‑agnostic .NET queue consumer + message pump. Includes Azure ServiceBus Queues adapter
 
 ## Typed routed handlers (agent-style)
@@ -10,13 +10,21 @@ the queue metadata contains a discriminator key `messageType`.
 using DotQueue;
 using Microsoft.Extensions.Logging;
 
-internal sealed class DecisionAgentQueueHandler(ILogger<DecisionAgentQueueHandler> logger)
-    : TypedRoutedQueueHandler(logger)
+internal sealed class DecisionAgentQueueHandler : TypedRoutedQueueHandler
 {
+    public DecisionAgentQueueHandler(ILogger<DecisionAgentQueueHandler> logger) : base(logger)
+    {
+        // Important: initialize routes after derived type construction is complete.
+        InitializeRoutes();
+    }
+
+    private const string InterventionContextV1 = "interventions.context.v1";
+    private const string DecisionInputV1 = "interventions.decision-input.v1";
+
     protected override RouteBuilder ConfigureRoutes(RouteBuilder routeBuilder)
         => routeBuilder
-            .AddHandler<InterventionContextData>(CollectContextAsync)
-            .AddHandler<DecisionAgentInput, InterventionDecisionResult>(MakeDecisionAsync);
+            .AddHandler<InterventionContextData>(InterventionContextV1, CollectContextAsync)
+            .AddHandler<DecisionAgentInput>(DecisionInputV1, MakeDecisionAsync);
 
     private static ValueTask CollectContextAsync(
         InterventionContextData message,
@@ -28,14 +36,14 @@ internal sealed class DecisionAgentQueueHandler(ILogger<DecisionAgentQueueHandle
         return ValueTask.CompletedTask;
     }
 
-    private static ValueTask<InterventionDecisionResult> MakeDecisionAsync(
+    private static ValueTask MakeDecisionAsync(
         DecisionAgentInput message,
         IReadOnlyDictionary<string, string>? metadata,
         Func<Task> renewLock,
         CancellationToken ct)
     {
-        var result = new InterventionDecisionResult();
-        return ValueTask.FromResult(result);
+        // Trigger next step through your own publisher/event bus if needed.
+        return ValueTask.CompletedTask;
     }
 }
 ```
@@ -64,15 +72,15 @@ services.AddTypedRoutedRabbitMQQueue<DecisionAgentQueueHandler>(
 
 ### Producer metadata contract
 
-Set metadata/header key `messageType` to the target CLR type name (or full name),
-and serialize the body as JSON for that type.
+Set metadata/header key `messageType` to a stable contract key
+(for example `interventions.context.v1`), then serialize the body as JSON.
 
 Azure Service Bus:
 
 ```csharp
 var body = JsonSerializer.Serialize(new InterventionContextData { /* ... */ });
 var message = new ServiceBusMessage(body);
-message.ApplicationProperties["messageType"] = nameof(InterventionContextData);
+message.ApplicationProperties["messageType"] = "interventions.context.v1";
 await sender.SendMessageAsync(message);
 ```
 
@@ -88,7 +96,7 @@ await channel.BasicPublishAsync(
     {
         Headers = new Dictionary<string, object?>
         {
-            ["messageType"] = Encoding.UTF8.GetBytes(nameof(InterventionContextData))
+            ["messageType"] = Encoding.UTF8.GetBytes("interventions.context.v1")
         }
     },
     body: body);

--- a/DotQueue/README.md
+++ b/DotQueue/README.md
@@ -1,2 +1,95 @@
-# DotQueue
+do# DotQueue
 Provider‑agnostic .NET queue consumer + message pump. Includes Azure ServiceBus Queues adapter
+
+## Typed routed handlers (agent-style)
+
+Use `TypedRoutedQueueHandler` when each incoming message has its own CLR type and
+the queue metadata contains a discriminator key `messageType`.
+
+```csharp
+using DotQueue;
+using Microsoft.Extensions.Logging;
+
+internal sealed class DecisionAgentQueueHandler(ILogger<DecisionAgentQueueHandler> logger)
+    : TypedRoutedQueueHandler(logger)
+{
+    protected override RouteBuilder ConfigureRoutes(RouteBuilder routeBuilder)
+        => routeBuilder
+            .AddHandler<InterventionContextData>(CollectContextAsync)
+            .AddHandler<DecisionAgentInput, InterventionDecisionResult>(MakeDecisionAsync);
+
+    private static ValueTask CollectContextAsync(
+        InterventionContextData message,
+        IReadOnlyDictionary<string, string>? metadata,
+        Func<Task> renewLock,
+        CancellationToken ct)
+    {
+        // Collect context from one-way message.
+        return ValueTask.CompletedTask;
+    }
+
+    private static ValueTask<InterventionDecisionResult> MakeDecisionAsync(
+        DecisionAgentInput message,
+        IReadOnlyDictionary<string, string>? metadata,
+        Func<Task> renewLock,
+        CancellationToken ct)
+    {
+        var result = new InterventionDecisionResult();
+        return ValueTask.FromResult(result);
+    }
+}
+```
+
+### DI registration
+
+Azure queue:
+
+```csharp
+services.AddTypedRoutedQueue<DecisionAgentQueueHandler>("interventions");
+```
+
+Azure session queue:
+
+```csharp
+services.AddTypedRoutedSessionQueue<DecisionAgentQueueHandler>("interventions");
+```
+
+RabbitMQ queue:
+
+```csharp
+services.AddTypedRoutedRabbitMQQueue<DecisionAgentQueueHandler>(
+    "amqp://user:pass@localhost:5672/",
+    "interventions");
+```
+
+### Producer metadata contract
+
+Set metadata/header key `messageType` to the target CLR type name (or full name),
+and serialize the body as JSON for that type.
+
+Azure Service Bus:
+
+```csharp
+var body = JsonSerializer.Serialize(new InterventionContextData { /* ... */ });
+var message = new ServiceBusMessage(body);
+message.ApplicationProperties["messageType"] = nameof(InterventionContextData);
+await sender.SendMessageAsync(message);
+```
+
+RabbitMQ:
+
+```csharp
+var body = JsonSerializer.SerializeToUtf8Bytes(new InterventionContextData { /* ... */ });
+await channel.BasicPublishAsync(
+    exchange: "",
+    routingKey: "interventions",
+    mandatory: false,
+    basicProperties: new BasicProperties
+    {
+        Headers = new Dictionary<string, object?>
+        {
+            ["messageType"] = Encoding.UTF8.GetBytes(nameof(InterventionContextData))
+        }
+    },
+    body: body);
+```

--- a/DotQueue/Rabbit/RabbitMqQueueListener.cs
+++ b/DotQueue/Rabbit/RabbitMqQueueListener.cs
@@ -1,4 +1,4 @@
-﻿using DotQueue;
+using DotQueue;
 using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
@@ -50,7 +50,7 @@ public sealed class RabbitMqQueueListener<T> : IQueueListener<T>, IAsyncDisposab
             {
                 var bodyBytes = ea.Body.ToArray();
 
-                var msg = JsonSerializer.Deserialize<T>(bodyBytes, _json)
+                var msg = DeserializeMessage(bodyBytes)
                           ?? throw new NonRetryableException("Deserialize failed");
 
                 var meta = ea.BasicProperties?.Headers?
@@ -98,5 +98,16 @@ public sealed class RabbitMqQueueListener<T> : IQueueListener<T>, IAsyncDisposab
     {
         try { if (_ch is not null) await _ch.DisposeAsync().ConfigureAwait(false); } catch { }
         try { if (_conn is not null) await _conn.DisposeAsync().ConfigureAwait(false); } catch { }
+    }
+
+    private T? DeserializeMessage(byte[] bodyBytes)
+    {
+        if (typeof(T) == typeof(RawQueueMessage))
+        {
+            var json = Encoding.UTF8.GetString(bodyBytes);
+            return (T)(object)new RawQueueMessage(json);
+        }
+
+        return JsonSerializer.Deserialize<T>(bodyBytes, _json);
     }
 }

--- a/DotQueue/Rabbit/RabbitMqServiceCollectionExtensions.cs
+++ b/DotQueue/Rabbit/RabbitMqServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 
@@ -34,6 +34,38 @@ public static class RabbitMqServiceCollectionExtensions
             ));
 
         services.AddHostedService<QueueProcessor<T>>();
+        return services;
+    }
+
+    public static IServiceCollection AddTypedRoutedRabbitMQQueue<TRoutedHandler>(
+        this IServiceCollection services,
+        string amqpConnectionString,
+        string queueName,
+        Action<QueueSettings>? configure = null)
+        where TRoutedHandler : TypedRoutedQueueHandler
+    {
+        services.AddScoped<TRoutedHandler>();
+        services.AddScoped<IQueueHandler<RawQueueMessage>>(sp => sp.GetRequiredService<TRoutedHandler>());
+
+        var settings = new QueueSettings();
+        configure?.Invoke(settings);
+        services.AddSingleton(settings);
+        services.AddSingleton<IRetryPolicyProvider, RetryPolicyProvider>();
+
+        services.AddSingleton<IConnectionFactory>(_ => new ConnectionFactory
+        {
+            Uri = new Uri(amqpConnectionString),
+        });
+        services.AddSingleton<IQueueListener<RawQueueMessage>>(sp =>
+            new RabbitMqQueueListener<RawQueueMessage>(
+                sp.GetRequiredService<IConnectionFactory>(),
+                queueName,
+                sp.GetRequiredService<QueueSettings>(),
+                sp.GetRequiredService<IRetryPolicyProvider>(),
+                sp.GetRequiredService<ILogger<RabbitMqQueueListener<RawQueueMessage>>>()
+            ));
+
+        services.AddHostedService<QueueProcessor<RawQueueMessage>>();
         return services;
     }
 }

--- a/DotQueue/RawQueueMessage.cs
+++ b/DotQueue/RawQueueMessage.cs
@@ -1,0 +1,7 @@
+namespace DotQueue;
+
+/// <summary>
+/// Raw queue payload for typed routing scenarios where concrete message type
+/// is selected from metadata (for example, "messageType") before deserialization.
+/// </summary>
+public sealed record RawQueueMessage(string Body);

--- a/DotQueue/TypedRoutedQueueHandler.cs
+++ b/DotQueue/TypedRoutedQueueHandler.cs
@@ -1,0 +1,139 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace DotQueue;
+
+public abstract class TypedRoutedQueueHandler : IQueueHandler<RawQueueMessage>
+{
+    public const string MessageTypeMetadataKey = "messageType";
+
+    private readonly ILogger _logger;
+    private readonly Dictionary<string, TypeRoute> _routesByMessageType = new(StringComparer.OrdinalIgnoreCase);
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    protected TypedRoutedQueueHandler(ILogger logger)
+    {
+        _logger = logger;
+        ConfigureRoutes(new RouteBuilder(this));
+    }
+
+    protected abstract RouteBuilder ConfigureRoutes(RouteBuilder routeBuilder);
+
+    protected delegate ValueTask HandlerDelegate(
+        object message,
+        IReadOnlyDictionary<string, string>? metadata,
+        Func<Task> renewLock,
+        CancellationToken ct);
+
+    protected virtual ValueTask InvokeHandlerAsync(
+        Type messageType,
+        HandlerDelegate handler,
+        object message,
+        IReadOnlyDictionary<string, string>? metadata,
+        Func<Task> renewLock,
+        CancellationToken ct) => handler(message, metadata, renewLock, ct);
+
+    private void Register(Type messageType, HandlerDelegate handler)
+    {
+        var route = new TypeRoute(messageType, handler);
+
+        // Register a few aliases to make producer-side naming flexible.
+        _routesByMessageType[messageType.Name] = route;
+        _routesByMessageType[messageType.FullName ?? messageType.Name] = route;
+        _routesByMessageType[messageType.AssemblyQualifiedName ?? messageType.Name] = route;
+    }
+
+    protected sealed class RouteBuilder
+    {
+        private readonly TypedRoutedQueueHandler _owner;
+
+        internal RouteBuilder(TypedRoutedQueueHandler owner) => _owner = owner;
+
+        public RouteBuilder AddHandler<TIn>(
+            Func<TIn, IReadOnlyDictionary<string, string>?, Func<Task>, CancellationToken, ValueTask> handler)
+        {
+            _owner.Register(
+                typeof(TIn),
+                (message, metadata, renewLock, ct) => handler((TIn)message, metadata, renewLock, ct));
+            return this;
+        }
+
+        public RouteBuilder AddHandler<TIn, TOut>(
+            Func<TIn, IReadOnlyDictionary<string, string>?, Func<Task>, CancellationToken, ValueTask<TOut>> handler)
+        {
+            _owner.Register(
+                typeof(TIn),
+                async (message, metadata, renewLock, ct) =>
+                {
+                    _ = await handler((TIn)message, metadata, renewLock, ct);
+                });
+            return this;
+        }
+    }
+
+    public async Task HandleAsync(
+        RawQueueMessage message,
+        IReadOnlyDictionary<string, string>? metadata,
+        Func<Task> renewLock,
+        CancellationToken ct)
+    {
+        if (metadata is null || !TryGetMessageType(metadata, out var messageType))
+        {
+            _logger.LogWarning("Missing required metadata key {MetadataKey}", MessageTypeMetadataKey);
+            throw new NonRetryableException($"Missing required metadata key '{MessageTypeMetadataKey}'.");
+        }
+
+        if (!_routesByMessageType.TryGetValue(messageType, out var route))
+        {
+            _logger.LogWarning("No handler registered for messageType {MessageType}", messageType);
+            throw new NonRetryableException($"No handler registered for messageType '{messageType}'.");
+        }
+
+        object typedMessage;
+        try
+        {
+            typedMessage = JsonSerializer.Deserialize(message.Body, route.MessageType, _jsonOptions)
+                ?? throw new NonRetryableException($"Failed to deserialize messageType '{messageType}'.");
+        }
+        catch (JsonException jex)
+        {
+            _logger.LogWarning(jex, "Failed to deserialize messageType {MessageType}", messageType);
+            throw new NonRetryableException($"Failed to deserialize messageType '{messageType}'.", jex);
+        }
+
+        await InvokeHandlerAsync(route.MessageType, route.Handler, typedMessage, metadata, renewLock, ct);
+    }
+
+    private static bool TryGetMessageType(IReadOnlyDictionary<string, string> metadata, out string messageType)
+    {
+        if (metadata.TryGetValue(MessageTypeMetadataKey, out var direct) && !string.IsNullOrWhiteSpace(direct))
+        {
+            messageType = direct;
+            return true;
+        }
+
+        foreach (var (key, value) in metadata)
+        {
+            if (!key.Equals(MessageTypeMetadataKey, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                messageType = value;
+                return true;
+            }
+
+            break;
+        }
+
+        messageType = string.Empty;
+        return false;
+    }
+
+    private sealed record TypeRoute(Type MessageType, HandlerDelegate Handler);
+}

--- a/DotQueue/TypedRoutedQueueHandler.cs
+++ b/DotQueue/TypedRoutedQueueHandler.cs
@@ -14,9 +14,21 @@ public abstract class TypedRoutedQueueHandler : IQueueHandler<RawQueueMessage>
         PropertyNameCaseInsensitive = true,
     };
 
-    protected TypedRoutedQueueHandler(ILogger logger)
+    private int _isInitialized;
+
+    protected TypedRoutedQueueHandler(ILogger logger) => _logger = logger;
+
+    /// <summary>
+    /// Initializes routes once. Call this from the derived constructor after the derived
+    /// type has finished its own initialization.
+    /// </summary>
+    protected void InitializeRoutes()
     {
-        _logger = logger;
+        if (Interlocked.Exchange(ref _isInitialized, 1) == 1)
+        {
+            return;
+        }
+
         ConfigureRoutes(new RouteBuilder(this));
     }
 
@@ -36,14 +48,15 @@ public abstract class TypedRoutedQueueHandler : IQueueHandler<RawQueueMessage>
         Func<Task> renewLock,
         CancellationToken ct) => handler(message, metadata, renewLock, ct);
 
-    private void Register(Type messageType, HandlerDelegate handler)
+    private void Register(string contractKey, Type messageType, HandlerDelegate handler)
     {
-        var route = new TypeRoute(messageType, handler);
+        if (string.IsNullOrWhiteSpace(contractKey))
+        {
+            throw new ArgumentException("Contract key cannot be null or whitespace.", nameof(contractKey));
+        }
 
-        // Register a few aliases to make producer-side naming flexible.
-        _routesByMessageType[messageType.Name] = route;
-        _routesByMessageType[messageType.FullName ?? messageType.Name] = route;
-        _routesByMessageType[messageType.AssemblyQualifiedName ?? messageType.Name] = route;
+        var route = new TypeRoute(messageType, handler);
+        _routesByMessageType[contractKey] = route;
     }
 
     protected sealed class RouteBuilder
@@ -53,23 +66,13 @@ public abstract class TypedRoutedQueueHandler : IQueueHandler<RawQueueMessage>
         internal RouteBuilder(TypedRoutedQueueHandler owner) => _owner = owner;
 
         public RouteBuilder AddHandler<TIn>(
+            string contractKey,
             Func<TIn, IReadOnlyDictionary<string, string>?, Func<Task>, CancellationToken, ValueTask> handler)
         {
             _owner.Register(
+                contractKey,
                 typeof(TIn),
                 (message, metadata, renewLock, ct) => handler((TIn)message, metadata, renewLock, ct));
-            return this;
-        }
-
-        public RouteBuilder AddHandler<TIn, TOut>(
-            Func<TIn, IReadOnlyDictionary<string, string>?, Func<Task>, CancellationToken, ValueTask<TOut>> handler)
-        {
-            _owner.Register(
-                typeof(TIn),
-                async (message, metadata, renewLock, ct) =>
-                {
-                    _ = await handler((TIn)message, metadata, renewLock, ct);
-                });
             return this;
         }
     }
@@ -80,6 +83,12 @@ public abstract class TypedRoutedQueueHandler : IQueueHandler<RawQueueMessage>
         Func<Task> renewLock,
         CancellationToken ct)
     {
+        if (Volatile.Read(ref _isInitialized) == 0)
+        {
+            throw new InvalidOperationException(
+                $"{GetType().Name} routes are not initialized. Call {nameof(InitializeRoutes)}() from the derived constructor.");
+        }
+
         if (metadata is null || !TryGetMessageType(metadata, out var messageType))
         {
             _logger.LogWarning("Missing required metadata key {MetadataKey}", MessageTypeMetadataKey);


### PR DESCRIPTION
Introduce agent-style typed routing for messages: add RawQueueMessage and TypedRoutedQueueHandler to route and dispatch messages by a metadata/header key (messageType). Update Azure and RabbitMQ listeners to special-case RawQueueMessage deserialization and to use the new typed routing pipeline. Add DI helpers for registering typed routed handlers for Azure (AddTypedRoutedQueue / AddTypedRoutedSessionQueue) and RabbitMQ (AddTypedRoutedRabbitMQQueue). Add unit and integration tests covering typed routing and service registrations, and update README with usage and producer metadata examples. Also include minor cleanup (usings) and JSON deserialization error handling that surfaces non-retryable errors for missing/unknown/invalid message types.